### PR TITLE
Potential fix for code scanning alert no. 5: Database query built from user-controlled sources

### DIFF
--- a/src/pages/api/auth/register.js
+++ b/src/pages/api/auth/register.js
@@ -11,11 +11,33 @@ export default async function handler(req, res) {
     if (!username || !firstName || !lastName || !email || !password) {
       return res.status(400).json({ message: 'Missing fields' });
     }
+
+    // Ensure all fields are strings to prevent NoSQL injection and other type-based issues
+    if (
+      typeof username !== 'string' ||
+      typeof firstName !== 'string' ||
+      typeof lastName !== 'string' ||
+      typeof email !== 'string' ||
+      typeof password !== 'string'
+    ) {
+      return res.status(400).json({ message: 'Invalid field types' });
+    }
+
+    // Optionally, trim to avoid purely whitespace values
+    if (
+      username.trim() === '' ||
+      firstName.trim() === '' ||
+      lastName.trim() === '' ||
+      email.trim() === '' ||
+      password.trim() === ''
+    ) {
+      return res.status(400).json({ message: 'Fields cannot be empty' });
+    }
   
     try {
       // Check if the user already exists by email or username
-      const existingEmailUser = await User.findOne({ email });
-      const existingUsernameUser = await User.findOne({ username });
+      const existingEmailUser = await User.findOne({ email: { $eq: email } });
+      const existingUsernameUser = await User.findOne({ username: { $eq: username } });
 
       if (existingEmailUser) {
         return res.status(400).json({ message: 'Email already in use' });


### PR DESCRIPTION
Potential fix for [https://github.com/zismaildev/Zismail-Shop/security/code-scanning/5](https://github.com/zismaildev/Zismail-Shop/security/code-scanning/5)

In general, to fix NoSQL injection when building MongoDB queries from user input, ensure that user-provided values are treated strictly as literals. This can be done by (1) validating that the values are of the expected primitive type (e.g., string) and rejecting anything else, and/or (2) wrapping them in `$eq` so they are interpreted as literal values, not query objects. Doing this close to where the values are first used in queries reduces the chance of missing a path.

For this specific handler, the least intrusive and clearest fix is:
- Add explicit type checks for `username`, `firstName`, `lastName`, `email`, and `password` so they must be non-empty strings.
- Optionally, we can also use `$eq` in the queries, but once we guarantee they are strings, using them directly is fine. To align with CodeQL’s recommended pattern and make the intent explicit, we’ll use `$eq` for both `email` and `username` in the `findOne` calls.

Concretely:
- In `src/pages/api/auth/register.js`, after destructuring from `req.body`, add checks ensuring each field is a string and not empty (e.g., `typeof email === 'string' && email.trim() !== ''`). If validation fails, return 400.
- Update:
  - `User.findOne({ email });` → `User.findOne({ email: { $eq: email } });`
  - `User.findOne({ username });` → `User.findOne({ username: { $eq: username } });`
- No new imports are needed; we only use built-in JS and Mongoose/MongoDB constructs already in use.

This preserves existing functionality (rejects missing data as before, and now also rejects malformed/non-string data) and removes the possibility that `email` or `username` is interpreted as a query object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
