### PR TITLE
Potential fix for code scanning alert no. 13: Host header poisoning in email generation

### DIFF
--- a/src/pages/api/auth/forgot-password.js
+++ b/src/pages/api/auth/forgot-password.js
@@ -20,6 +20,8 @@ export default async function handler(req, res) {
       user.resetPasswordExpires = Date.now() + 3600000; // 1 hour
       await user.save();
 
+      const baseUrl = process.env.APP_BASE_URL || "http://localhost:3000";
+
       const transporter = nodemailer.createTransport({
         service: "Gmail",
         auth: {
@@ -34,7 +36,7 @@ export default async function handler(req, res) {
         subject: "Password Reset",
         text: `You are receiving this because you (or someone else) have requested the reset of the password for your account.\n\n
           Please click on the following link, or paste this into your browser to complete the process:\n\n
-          http://${req.headers.host}/reset-password?token=${token}\n\n
+          ${baseUrl}/reset-password?token=${token}\n\n
           If you did not request this, please ignore this email and your password will remain unchanged.\n`,
       };
 


### PR DESCRIPTION
Potential fix for [https://github.com/zismaildev/Zismail-Shop/security/code-scanning/13](https://github.com/zismaildev/Zismail-Shop/security/code-scanning/13)

In general, to fix Host header poisoning in email generation, avoid using `req.headers.host` (or any value derived from the HTTP Host header) to construct links. Instead, derive the application’s base URL from trusted configuration: environment variables, a config file, or a hard-coded constant checked into the code. This trusted base URL is then concatenated with the password reset path and token.

For this specific file, the best minimal fix is to introduce a trusted base URL, for example from an environment variable such as `process.env.APP_BASE_URL` (or similar), and use that instead of `req.headers.host`. This preserves existing functionality (emails still contain a clickable reset link with the correct token), but removes the attacker-controlled component.

Concretely:
- Define a constant in `handler` (or at module scope) that reads the base URL from an environment variable, with a safe default if needed (e.g. `http://localhost:3000` for development).
- Replace `http://${req.headers.host}/reset-password?token=${token}` with `${BASE_URL}/reset-password?token=${token}` where `BASE_URL` is that trusted constant.
- Keep all other logic (token generation, email composition, sending) unchanged.

All required constructs (`process.env`) are already available in Node/Next.js; no new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
