### PR TITLE
Potential fix for code scanning alert no. 12: Database query built from user-controlled sources

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -34,7 +34,8 @@ export async function sendResetPasswordEmail(identifier) {
 export async function resetUserPassword(identifier, newPassword) {
   const db = await getDatabaseConnection();
   const hashedPassword = await bcrypt.hash(newPassword, 10);
-  await db.collection('users').updateOne({ email: identifier }, { $set: { password: hashedPassword } });
+  const email = String(identifier);
+  await db.collection('users').updateOne({ email }, { $set: { password: hashedPassword } });
 }
 
 export function verifyToken(token) {


### PR DESCRIPTION
Potential fix for [https://github.com/zismaildev/Zismail-Shop/security/code-scanning/12](https://github.com/zismaildev/Zismail-Shop/security/code-scanning/12)

In general, to fix NoSQL injection risks you must ensure that any untrusted data used in a query is either: (a) wrapped in an operator like `$eq` so it is always interpreted as a literal value, or (b) validated/coerced to a safe primitive type (string, number, boolean) before use, rejecting or sanitizing objects that could contain special operator keys. The key is to prevent attacker-controlled objects from being used directly as query documents or subdocuments.

For this specific case, we can preserve existing behavior while making the query safe by enforcing that `identifier` is a string before using it in the MongoDB `updateOne` call. The most straightforward and non‑intrusive way is to coerce `identifier` to a string (e.g. `String(identifier)`) so that even if an attacker sends an object, it will be converted to its string representation rather than being interpreted as a query object. This keeps the API and logic intact (lookup still happens by email, now using the stringified version of the input) and does not require changes elsewhere in the code. Optionally, an even stricter variant would be to check `typeof identifier === 'string'` and throw or return an error otherwise, but that would change behavior; to avoid changing existing functionality, simple coercion is safer.

Concretely:
- In `src/utils/auth.js`, inside `resetUserPassword`, introduce a local variable such as `const email = String(identifier);`.
- Use this `email` variable in the query filter: `updateOne({ email }, ...)`.
- No new imports are required.

This ensures that the query filter always contains a primitive string value and eliminates the potential for NoSQL injection through query object injection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
